### PR TITLE
update appeng ruby runtime to 27

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: ruby25
+runtime: ruby27
 entrypoint: bundle exec jekyll serve -P $PORT --safe --skip-initial-build --no-watch --trace
 instance_class: B1
 basic_scaling:


### PR DESCRIPTION
Ruby 25 was deprecated by appeng in March 2021, migrating the env to 27 should work with Jekyll without any additional issues